### PR TITLE
Prevent app from exiting on configuration change

### DIFF
--- a/app/src/main/java/github/daisukikaffuchino/rebootnya/fragment/HomeFragment.java
+++ b/app/src/main/java/github/daisukikaffuchino/rebootnya/fragment/HomeFragment.java
@@ -152,7 +152,9 @@ public class HomeFragment extends DialogFragment {
     @Override
     public void onDismiss(@NonNull DialogInterface dialog) {
         super.onDismiss(dialog);
-        System.exit(0);
+        if (!requireActivity().isChangingConfigurations()) {
+            requireActivity().finish();
+        }
     }
 
 }


### PR DESCRIPTION
此前，在系统中切换浅色/深色模式会导致应用退出。

这是因为主题变更属于配置变更 (Configuration Change)，会触发 Activity 的销毁和重建。Activity 的重建过程会关闭 (dismiss) 当前显示的 `HomeFragment` 对话框，从而调用 `onDismiss` 回调。该回调中的 `System.exit(0)` 语句是导致应用意外关闭的直接原因。

本次提交通过在 `onDismiss` 回调中增加一个判断条件 `!requireActivity().isChangingConfigurations()` 来解决此问题。

`isChangingConfigurations()` 方法可以区分出 Activity 是由用户操作关闭还是因系统配置变更而关闭。现在，只有在用户主动关闭对话框时（例如按返回键），应用才会退出。在切换主题时，应用将不再关闭，可以无缝地重新加载界面以应用新主题。

另外，AI 给出了一条最佳实践建议：
避免使用 System.exit(0)：在 Android 开发中应极力避免使用 `System.exit(0)` 来退出应用。Android 系统有自己的任务和进程管理机制，强制退出可能会绕过正常的生命周期回调，导致资源无法正确释放等问题。

~_今夜睡觉神游时想到了这个问题，并觉得这可能是可以被修复的，遂起身使用 AI 并且成功修复_~