### PR TITLE
Fix: Correct corner radius for recycled list items

### DIFF
--- a/app/src/main/java/github/daisukikaffuchino/rebootnya/adapter/HomeListAdapter.kt
+++ b/app/src/main/java/github/daisukikaffuchino/rebootnya/adapter/HomeListAdapter.kt
@@ -75,24 +75,31 @@ class HomeListAdapter(
         holder.btn.setTextColor(translucentTextColor)
         holder.btn.setOnClickListener { view -> clickListener.onClick(position) }
 
-        if (position == 0) {
-            holder.btn.shapeAppearanceModel = ShapeAppearanceModel()
-                .toBuilder()
-                .setTopLeftCorner(CornerFamily.ROUNDED, 48f)
-                .setTopRightCorner(CornerFamily.ROUNDED, 48f)
-                .setBottomLeftCorner(CornerFamily.ROUNDED, 12f)
-                .setBottomRightCorner(CornerFamily.ROUNDED, 12f)
-                .build()
-        }
-
-        if (position == items.size - 1) {
-            holder.btn.shapeAppearanceModel = ShapeAppearanceModel()
-                .toBuilder()
-                .setTopLeftCorner(CornerFamily.ROUNDED, 12f)
-                .setTopRightCorner(CornerFamily.ROUNDED, 12f)
-                .setBottomLeftCorner(CornerFamily.ROUNDED, 48f)
-                .setBottomRightCorner(CornerFamily.ROUNDED, 48f)
-                .build()
+        when (position) {
+            0 -> {
+                holder.btn.shapeAppearanceModel = ShapeAppearanceModel()
+                    .toBuilder()
+                    .setTopLeftCorner(CornerFamily.ROUNDED, 48f)
+                    .setTopRightCorner(CornerFamily.ROUNDED, 48f)
+                    .setBottomLeftCorner(CornerFamily.ROUNDED, 12f)
+                    .setBottomRightCorner(CornerFamily.ROUNDED, 12f)
+                    .build()
+            }
+            items.size - 1 -> {
+                holder.btn.shapeAppearanceModel = ShapeAppearanceModel()
+                    .toBuilder()
+                    .setTopLeftCorner(CornerFamily.ROUNDED, 12f)
+                    .setTopRightCorner(CornerFamily.ROUNDED, 12f)
+                    .setBottomLeftCorner(CornerFamily.ROUNDED, 48f)
+                    .setBottomRightCorner(CornerFamily.ROUNDED, 48f)
+                    .build()
+            }
+            else -> {
+                holder.btn.shapeAppearanceModel = ShapeAppearanceModel()
+                    .toBuilder()
+                    .setAllCorners(CornerFamily.ROUNDED, 12f)
+                    .build()
+            }
         }
 
         return view


### PR DESCRIPTION
滚动时，回收的视图保留了第一个或最后一个项目的大圆角半径，导致视觉错误。
When scrolling, recycled views retained the large corner radii from the first or last items, causing visual bugs.

逻辑已更新为 `when` 块，以明确处理默认情况，确保形状始终被正确设置。
The logic is updated to a `when` block to explicitly handle the default case, ensuring the shape is always set correctly.

![Snipaste_2025-08-24_20-56-41](https://github.com/user-attachments/assets/c1ab5085-2fb5-4682-9f3c-0bf727e1ba6c)
